### PR TITLE
feat: Enable the privacy plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,8 @@ plugins:
       enable_creation_date: true
       type: iso_date
       timezone: Asia/Shanghai
+  - privacy:
+      enabled: !ENV [CI, false]
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
这样可以让 GitHub 托管 Google Fonts。

[Built-in privacy plugin - Material for MkDocs](https://squidfunk.github.io/mkdocs-material/plugins/privacy/)

编译输出示例：https://github.com/BITNP/cheesy-shrimp/pull/4